### PR TITLE
feat: prefer UInt8Array, ban nodejs Buffer

### DIFF
--- a/.changeset/dull-flowers-tie.md
+++ b/.changeset/dull-flowers-tie.md
@@ -1,0 +1,12 @@
+---
+'@belgattitude/eslint-config-bases': minor
+---
+
+Ban node.js buffer by default, prefer UInt8Array
+
+> See reasoning in https://sindresorhus.com/blog/goodbye-nodejs-buffer
+
+There's a transitional package that helps to fill current gaps in UInt8Array
+till limitations lands into ecmascript.
+
+https://github.com/sindresorhus/uint8array-extras

--- a/packages/eslint-config-bases/src/bases/typescript.js
+++ b/packages/eslint-config-bases/src/bases/typescript.js
@@ -87,6 +87,38 @@ module.exports = {
         alphabetize: { order: 'asc', caseInsensitive: true },
       },
     ],
+    // https://sindresorhus.com/blog/goodbye-nodejs-buffer
+    'no-restricted-globals': [
+      'error',
+      {
+        name: 'Buffer',
+        message: 'Use Uint8Array instead.',
+      },
+    ],
+    // https://sindresorhus.com/blog/goodbye-nodejs-buffer
+    'no-restricted-imports': [
+      'error',
+      {
+        name: 'buffer',
+        message: 'Use Uint8Array instead.',
+      },
+      {
+        name: 'node:buffer',
+        message: 'Use Uint8Array instead.',
+      },
+    ],
+    // https://sindresorhus.com/blog/goodbye-nodejs-buffer
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          Buffer: {
+            message: 'Use Uint8Array instead.',
+            suggest: ['Uint8Array'],
+          },
+        },
+      },
+    ],
     // https://github.com/sweepline/eslint-plugin-unused-imports
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',


### PR DESCRIPTION
Ban node.js buffer by default, prefer UInt8Array

> See reasoning in https://sindresorhus.com/blog/goodbye-nodejs-buffer

There's a transitional package that helps to fill current gaps in UInt8Array
till limitations lands into ecmascript.

https://github.com/sindresorhus/uint8array-extras