### PR TITLE
fix: @typescript-eslint/typescript-estree at latest

### DIFF
--- a/.changeset/beige-insects-hug.md
+++ b/.changeset/beige-insects-hug.md
@@ -1,0 +1,5 @@
+---
+'@belgattitude/eslint-config-bases': patch
+---
+
+Ensure @typescript-eslint/typescript-estree is at latest

--- a/packages/eslint-config-bases/package.json
+++ b/packages/eslint-config-bases/package.json
@@ -92,6 +92,7 @@
     "@tanstack/eslint-plugin-query": "^4.36.1 || ^5.8.4",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
+    "@typescript-eslint/typescript-estree": "^6.12.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.0",


### PR DESCRIPTION
Consuming apps/projects might get stick on an older @typescript-eslint/typescript-estree version. Let's enforce the latest