### PR TITLE
feat: extract import/export sort

### DIFF
--- a/.changeset/lovely-radios-smash.md
+++ b/.changeset/lovely-radios-smash.md
@@ -1,0 +1,26 @@
+---
+'@belgattitude/eslint-config-bases': minor
+---
+
+Disable eslint-plugin-import sort
+
+In preparation for dprint support, you must now opt-in for import/export sort. 
+
+```js
+module.exports = {
+    // for brevity
+    extends: [
+        // Group 1: recommended always
+        '@belgattitude/eslint-config-bases/typescript',
+        '@belgattitude/eslint-config-bases/simple-import-sort',
+        // ...rest
+    ],
+}
+```
+
+Note that the [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) has been changed to [simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort)
+internally. Expect to relint your codebase.
+
+This change bring some speedups. In a next release those rules can be opt-out
+easily in favour of dprint, biome... which does as faster job (stylistic)
+

--- a/examples/nextjs-app/.eslintrc.cjs
+++ b/examples/nextjs-app/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
   extends: [
     // Group 1: recommended always
     '@belgattitude/eslint-config-bases/typescript',
+    '@belgattitude/eslint-config-bases/simple-import-sort',
     '@belgattitude/eslint-config-bases/regexp',
     '@belgattitude/eslint-config-bases/jest', // jest or similar (ie: vitest)
 

--- a/examples/nextjs-app/next.config.mjs
+++ b/examples/nextjs-app/next.config.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import withBundleAnalyzer from '@next/bundle-analyzer';
 import nextMdx from '@next/mdx';
 import { createSecureHeaders } from 'next-secure-headers';
+
 import { getValidatedServerEnv } from './src/config/validated-server-env.mjs';
 
 const _serverEnv = getValidatedServerEnv();

--- a/examples/nextjs-app/src/app/(public)/layout.tsx
+++ b/examples/nextjs-app/src/app/(public)/layout.tsx
@@ -1,6 +1,8 @@
 import '@/styles/globals.css';
+
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
+
 import { MainLayout } from '@/components/layout/main-layout';
 
 export const metadata: Metadata = {};

--- a/examples/nextjs-app/src/components/button/Button.stories.tsx
+++ b/examples/nextjs-app/src/components/button/Button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+
 import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {

--- a/examples/nextjs-app/src/components/button/Button.tsx
+++ b/examples/nextjs-app/src/components/button/Button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
-import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { type ButtonHTMLAttributes, forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {

--- a/examples/nextjs-app/src/components/layout/main-layout.tsx
+++ b/examples/nextjs-app/src/components/layout/main-layout.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import type { FC, PropsWithChildren } from 'react';
+
 import { MainFooter } from '@/components/layout/main-footer';
+
 import { MainNav } from './main-nav';
 
 type Props = PropsWithChildren & {

--- a/examples/nextjs-app/src/components/layout/main-nav.tsx
+++ b/examples/nextjs-app/src/components/layout/main-nav.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { twMerge } from 'tailwind-merge';
+
 import { useMainLayoutStore } from '@/components/layout/main-layout-store';
 import { MainSidebar } from '@/components/layout/sidebar/main-sidebar';
 import { siteConfig } from '@/config/site.config';

--- a/examples/nextjs-app/src/components/layout/sidebar/main-sidebar.tsx
+++ b/examples/nextjs-app/src/components/layout/sidebar/main-sidebar.tsx
@@ -3,6 +3,7 @@
 import { clsx } from 'clsx';
 import Link from 'next/link';
 import type { FC } from 'react';
+
 import { useMainLayoutStore } from '@/components/layout/main-layout-store';
 import type { SiteConfig } from '@/config/site.config';
 

--- a/examples/nextjs-app/src/lib/factory/ky.factory.ts
+++ b/examples/nextjs-app/src/lib/factory/ky.factory.ts
@@ -1,4 +1,4 @@
-import Ky, { type Options, type NormalizedOptions } from 'ky';
+import Ky, { type NormalizedOptions, type Options } from 'ky';
 
 type Props = {
   baseUrl?: string;

--- a/examples/nextjs-app/src/providers/ReactQueryProvider.tsx
+++ b/examples/nextjs-app/src/providers/ReactQueryProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useState, type ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 
 export function ReactQueryProvider({
   children,

--- a/examples/nextjs-app/src/types.d/env.d.ts
+++ b/examples/nextjs-app/src/types.d/env.d.ts
@@ -1,4 +1,5 @@
 import { type z } from 'zod';
+
 import { type serverEnvSchema } from '../config/validated-server-env.mjs';
 
 type ValidatedProcessEnv = z.infer<typeof serverEnvSchema>;

--- a/examples/nextjs-app/src/types.d/react-svgr.d.ts
+++ b/examples/nextjs-app/src/types.d/react-svgr.d.ts
@@ -19,6 +19,7 @@
 
 declare module '*.svg' {
   import type React from 'react';
+
   const svg: React.FC<React.SVGProps<SVGSVGElement>>;
   export default svg;
 }

--- a/packages/eslint-config-bases/.eslintrc.cjs
+++ b/packages/eslint-config-bases/.eslintrc.cjs
@@ -3,6 +3,8 @@ const { getDefaultIgnorePatterns } = require('./src/helpers');
 module.exports = {
   extends: [
     './src/bases/typescript',
+    './src/bases/simple-import-sort',
+    './src/bases/regexp',
     './src/bases/perfectionist',
     './src/bases/performance',
     './src/bases/prettier-plugin',

--- a/packages/eslint-config-bases/README.md
+++ b/packages/eslint-config-bases/README.md
@@ -54,6 +54,7 @@ module.exports = {
     // Group 1: recommended always  
       
     "@belgattitude/eslint-config-bases/typescript",
+    "@belgattitude/eslint-config-bases/simple-import-sort",
     "@belgattitude/eslint-config-bases/regexp",
     "@belgattitude/eslint-config-bases/jest", // jest or similar (ie: vitest)
       

--- a/packages/eslint-config-bases/package.json
+++ b/packages/eslint-config-bases/package.json
@@ -67,6 +67,9 @@
     "./regexp": {
       "require": "./src/bases/regexp.js"
     },
+    "./simple-import-sort": {
+      "require": "./src/bases/simple-import-sort.js"
+    },
     "./sonar": {
       "require": "./src/bases/sonar.js"
     },
@@ -106,6 +109,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0 || 5.0.0-canary-7118f5dd7-20230705",
     "eslint-plugin-regexp": "^2.1.1",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-sonarjs": "^0.23.0",
     "eslint-plugin-storybook": "^0.6.15",
     "eslint-plugin-testing-library": "^6.2.0",

--- a/packages/eslint-config-bases/src/bases/index.js
+++ b/packages/eslint-config-bases/src/bases/index.js
@@ -12,6 +12,7 @@ module.exports = {
   reactQuery: require('./react-query'),
   reactTestingLibrary: require('./rtl'),
   regexp: require('./regexp'),
+  'simple-import-sort': require('./simple-import-sort'),
   sonar: require('./sonar'),
   storybook: require('./storybook'),
   tailwind: require('./tailwind'),

--- a/packages/eslint-config-bases/src/bases/prettier-plugin.js
+++ b/packages/eslint-config-bases/src/bases/prettier-plugin.js
@@ -4,6 +4,7 @@
  */
 
 const { getPrettierConfig } = require('../helpers');
+
 const { ...prettierConfig } = getPrettierConfig();
 
 module.exports = {

--- a/packages/eslint-config-bases/src/bases/simple-import-sort.js
+++ b/packages/eslint-config-bases/src/bases/simple-import-sort.js
@@ -1,0 +1,18 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  plugins: ['simple-import-sort', 'import'],
+  rules: {
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-duplicates': 'error',
+    'linebreak-style': ['error', 'unix'],
+    'no-duplicate-imports': 'off',
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
+    'sort-imports': 'off',
+  },
+};

--- a/packages/eslint-config-bases/src/bases/typescript.js
+++ b/packages/eslint-config-bases/src/bases/typescript.js
@@ -18,8 +18,6 @@ module.exports = {
   },
   extends: [
     'eslint:recommended',
-    'plugin:import/recommended',
-    'plugin:import/typescript',
     'plugin:@typescript-eslint/recommended-type-checked',
     'plugin:@typescript-eslint/stylistic-type-checked',
     'plugin:unicorn/recommended',
@@ -44,12 +42,6 @@ module.exports = {
         '@typescript-eslint/no-unsafe-member-access': 'off',
         // https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
         '@typescript-eslint/unbound-method': 'off',
-        'import/default': 'off',
-        // Relax rules that are known to be slow and less useful in a test context
-        'import/namespace': 'off',
-        'import/no-duplicates': 'off',
-        // Relax rules that makes writing tests easier
-        'import/no-named-as-default-member': 'off',
         'require-await': 'off',
         'unicorn/no-null': 'off',
         'unicorn/no-useless-undefined': 'off',
@@ -57,7 +49,7 @@ module.exports = {
         'unicorn/error-message': 'off',
         'unicorn/consistent-function-scoping': 'off',
         'unicorn/no-await-expression-member': 'off',
-        'unicorn/oprefer-add-event-listener': 'off',
+        'unicorn/prefer-add-event-listener': 'off',
       },
     },
     {
@@ -176,35 +168,8 @@ module.exports = {
       },
     ],
     '@typescript-eslint/unbound-method': ['error', { ignoreStatic: true }],
-    'import/no-unresolved': 'off',
-    'import/default': 'off',
-    // Caution this rule is slow https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/namespace.md
-    'import/namespace': 'off', // ['error'] If you want the extra check (typechecking will spot most issues already)
-    // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md
-    'import/no-duplicates': [
-      'error',
-      { considerQueryString: true, 'prefer-inline': true },
-    ],
-    'import/no-named-as-default': ['warn'],
-    'import/no-named-as-default-member': ['warn'],
-    'import/order': [
-      'error',
-      {
-        alphabetize: { caseInsensitive: true, order: 'asc' },
-        groups: [
-          'builtin',
-          'external',
-          'internal',
-          'parent',
-          'sibling',
-          'index',
-          'object',
-        ],
-      },
-    ],
     'linebreak-style': ['error', 'unix'],
     'no-constant-binary-expression': 'error',
-    // will use 'import/no-duplicates'.
     'no-duplicate-imports': 'off',
     'no-empty': [
       'error',
@@ -251,6 +216,7 @@ module.exports = {
         },
       },
     ],
+    'sort-imports': 'off',
     'unused-imports/no-unused-imports': 'error',
     'unused-imports/no-unused-vars': [
       'warn',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,8 @@ __metadata:
     es-check: "npm:7.1.1"
     eslint: "npm:8.54.0"
     eslint-config-prettier: "npm:^9.0.0"
+    eslint-import-resolver-typescript: "npm:^3.6.1"
+    eslint-plugin-import: "npm:^2.29.0"
     eslint-plugin-jest: "npm:^27.6.0"
     eslint-plugin-jest-formatting: "npm:^3.1.0"
     eslint-plugin-jsx-a11y: "npm:^6.8.0"
@@ -10451,7 +10453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^3.5.2":
+"eslint-import-resolver-typescript@npm:^3.5.2, eslint-import-resolver-typescript@npm:^3.6.1":
   version: 3.6.1
   resolution: "eslint-import-resolver-typescript@npm:3.6.1"
   dependencies:
@@ -10505,7 +10507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.28.1":
+"eslint-plugin-import@npm:^2.28.1, eslint-plugin-import@npm:^2.29.0":
   version: 2.29.0
   resolution: "eslint-plugin-import@npm:2.29.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,8 +1593,6 @@ __metadata:
     es-check: "npm:7.1.1"
     eslint: "npm:8.54.0"
     eslint-config-prettier: "npm:^9.0.0"
-    eslint-import-resolver-typescript: "npm:^3.6.1"
-    eslint-plugin-import: "npm:^2.29.0"
     eslint-plugin-jest: "npm:^27.6.0"
     eslint-plugin-jest-formatting: "npm:^3.1.0"
     eslint-plugin-jsx-a11y: "npm:^6.8.0"
@@ -1605,6 +1603,7 @@ __metadata:
     eslint-plugin-react: "npm:^7.33.2"
     eslint-plugin-react-hooks: "npm:^4.6.0 || 5.0.0-canary-7118f5dd7-20230705"
     eslint-plugin-regexp: "npm:^2.1.1"
+    eslint-plugin-simple-import-sort: "npm:^10.0.0"
     eslint-plugin-sonarjs: "npm:^0.23.0"
     eslint-plugin-storybook: "npm:^0.6.15"
     eslint-plugin-tailwindcss: "npm:3.13.0"
@@ -10452,7 +10451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^3.5.2, eslint-import-resolver-typescript@npm:^3.6.1":
+"eslint-import-resolver-typescript@npm:^3.5.2":
   version: 3.6.1
   resolution: "eslint-import-resolver-typescript@npm:3.6.1"
   dependencies:
@@ -10506,7 +10505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.28.1, eslint-plugin-import@npm:^2.29.0":
+"eslint-plugin-import@npm:^2.28.1":
   version: 2.29.0
   resolution: "eslint-plugin-import@npm:2.29.0"
   dependencies:
@@ -10724,6 +10723,15 @@ __metadata:
   peerDependencies:
     eslint: ">=8.44.0"
   checksum: fd13d860d1460bb2f07387d5ebac4eeb4d17f5c440ef4bf5c86f9eda8b4f33b07a09444b15c01ec5463cfcec790f5a8125eee7e1ed30b4ced289c954d3434c23
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-simple-import-sort@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "eslint-plugin-simple-import-sort@npm:10.0.0"
+  peerDependencies:
+    eslint: ">=5.0.0"
+  checksum: 1ae0814d23816d51d010cfbc5ee0a0dde8d825a3093876b2e8219a0562d53f4d4794508551e503ebe2ea98904cb35204dbe54dfbf9d7fc8b8e3ea25c52aa68ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Disable eslint-plugin-import sort

In preparation for dprint support, you must now opt-in for import/export sort. 

```js
module.exports = {
    // for brevity
    extends: [
        // Group 1: recommended always
        '@belgattitude/eslint-config-bases/typescript',
        '@belgattitude/eslint-config-bases/simple-import-sort',
        // ...rest
    ],
}
```

Note that the [eslint-plugin-import](https://github.com/import-js/eslint-plugin-import) has been changed to [simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort)
internally. Expect to relint your codebase.

This change bring some speedups. In a next release those rules can be opt-out
easily in favour of dprint, biome... which does as faster job (stylistic)