### PR TITLE
feat: @typescript-eslint/method-signature-style

### DIFF
--- a/.changeset/olive-brooms-prove.md
+++ b/.changeset/olive-brooms-prove.md
@@ -1,0 +1,12 @@
+---
+"@belgattitude/eslint-config-bases": minor
+---
+
+Enforce "@typescript-eslint/method-signature-style" property by default
+
+Link https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
+
+```
+// https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
+'@typescript-eslint/method-signature-style': ['error', 'property'],
+```

--- a/packages/eslint-config-bases/src/bases/typescript.js
+++ b/packages/eslint-config-bases/src/bases/typescript.js
@@ -123,6 +123,8 @@ module.exports = {
         'ts-nocheck': true,
       },
     ],
+    // https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful
+    '@typescript-eslint/method-signature-style': ['error', 'property'],
     // https://sindresorhus.com/blog/goodbye-nodejs-buffer
     '@typescript-eslint/ban-types': [
       'error',


### PR DESCRIPTION
https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful